### PR TITLE
free_listからclear_cmdを削除して参照NULLにするだけにした。Testerはダブルポインタ対応にした

### DIFF
--- a/srcs/exec/astree2list.c
+++ b/srcs/exec/astree2list.c
@@ -6,7 +6,7 @@
 /*   By: tkatsuma <tkatsuma@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/23 18:48:16 by htsutsum          #+#    #+#             */
-/*   Updated: 2025/11/26 23:04:47 by tkatsuma         ###   ########.fr       */
+/*   Updated: 2025/11/27 16:15:50 by tkatsuma         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -67,7 +67,6 @@ void	free_list(t_list **list)
 		next_node = current->next;
 		if (current->content != NULL)
 		{
-			clear_cmd((t_cmd **) &(current->content));
 			current->content = NULL;
 		}
 		free(current);

--- a/srcs/parser/astree.c
+++ b/srcs/parser/astree.c
@@ -6,7 +6,7 @@
 /*   By: tkatsuma <tkatsuma@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/10/30 01:38:27 by htsutsum          #+#    #+#             */
-/*   Updated: 2025/11/27 13:23:15 by tkatsuma         ###   ########.fr       */
+/*   Updated: 2025/11/27 16:09:51 by tkatsuma         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -92,6 +92,8 @@ void	astree_clear(t_astree **node)
 {
 	if (!node || !(*node))
 		return ;
+	if ((*node)->cmd != NULL)
+		clear_cmd(&(*node)->cmd);
 	(*node)->cmd = NULL;
 	astree_clear(&(*node)->left);
 	astree_clear(&(*node)->right);

--- a/test/expansion_test.c
+++ b/test/expansion_test.c
@@ -6,7 +6,7 @@
 /*   By: tkatsuma <tkatsuma@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/12 02:49:44 by tkatsuma          #+#    #+#             */
-/*   Updated: 2025/11/21 11:56:51 by tkatsuma         ###   ########.fr       */
+/*   Updated: 2025/11/27 16:14:08 by tkatsuma         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,7 +48,7 @@ int	test_single_cmd(t_shell *shell, char *input, char *cmd1, char *path1)
 	else
 		printf("[%s] -> FAIL (status: %d)\n", input, status);
 	
-	astree_clear(astree_head);
+	astree_clear(&astree_head);
 	return (status);
 }
 
@@ -72,7 +72,7 @@ int	test_cmd1_arg1_red1(t_shell *shell, char *input, char *cmd1, char *arg1, cha
 	else
 		printf("[%s] -> FAIL (status: %d)\n", input, status);
 	
-	astree_clear(astree_head);
+	astree_clear(&astree_head);
 	return (status);
 }
 
@@ -97,7 +97,7 @@ int	test_cmd1_arg1_red2(t_shell *shell, char *input, char *cmd1, char *arg1, cha
 	else
 		printf("[%s] -> FAIL (status: %d)\n", input, status);
 	
-	astree_clear(astree_head);
+	astree_clear(&astree_head);
 	return (status);
 }
 

--- a/test/parser_test.c
+++ b/test/parser_test.c
@@ -6,7 +6,7 @@
 /*   By: tkatsuma <tkatsuma@student.42tokyo.jp>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/12 02:49:44 by tkatsuma          #+#    #+#             */
-/*   Updated: 2025/11/21 03:12:36 by tkatsuma         ###   ########.fr       */
+/*   Updated: 2025/11/27 16:13:12 by tkatsuma         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -54,7 +54,7 @@ int	test_single_cmd(char *input)
 		printf("[%s] -> PASS (status: %d)\n", input, status);
 	else
 		printf("[%s] -> FAIL (status: %d)\n", input, status);
-	astree_clear(astree);
+	astree_clear(&astree);
 	return (status);
 }
 
@@ -74,7 +74,7 @@ int	test_cmd1_arg1(char *input, char *cmd1, char *arg1)
 		printf("[%s] -> PASS (status: %d)\n", input, status);
 	else
 		printf("[%s] -> FAIL (status: %d)\n", input, status);
-	astree_clear(astree);
+	astree_clear(&astree);
 	return (status);
 }
 
@@ -95,7 +95,7 @@ int	test_cmd1_arg2(char *input, char *cmd1, char *arg1, char *arg2)
 		printf("[%s] -> PASS (status: %d)\n", input, status);
 	else
 		printf("[%s] -> FAIL (status: %d)\n", input, status);
-	astree_clear(astree);
+	astree_clear(&astree);
 	return (status);
 }
 
@@ -129,7 +129,7 @@ int	test_cmd1_arg1_pipe_cmd2_arg2(
 		printf("[%s] -> FAIL (status: %d)\n", input, status);
 	else
 		printf("[%s] -> PASS (status: %d)\n", input, status);
-	astree_clear(head);
+	astree_clear(&head);
 	return (status);
 }
 
@@ -172,7 +172,7 @@ int	test_cmd1_arg1_pipe_cmd2_arg2_pipe_cmd3_arg3(
 		printf("[%s] -> FAIL (status: %d)\n", input, status);
 	else
 		printf("[%s] -> PASS (status: %d)\n", input, status);
-	astree_clear(head);
+	astree_clear(&head);
 	return (status);
 }
 
@@ -194,7 +194,7 @@ int	test_cmd1_arg1_red1(char *input, char *cmd1, char *arg1, char *red1, t_tkind
 		printf("[%s] -> PASS (status: %d)\n", input, status);
 	else
 		printf("[%s] -> FAIL (status: %d)\n", input, status);
-	astree_clear(astree);
+	astree_clear(&astree);
 	return (status);
 }
 
@@ -211,7 +211,7 @@ int	test_failure(char *input)
 		printf("[%s] -> PASS (status: %d)\n", input, status);
 	else
 		printf("[%s] -> FAIL (status: %d)\n", input, status);
-	astree_clear(astree);
+	astree_clear(&astree);
 	return (status);
 }
 


### PR DESCRIPTION
Astree_clearとfree_listの二つでClear_cmdを読んでいてDoubleFreeになっていたので、
free_listからclear_cmdを削除して,参照ポインタをNULLにするだけにしました。
Testerはダブルポインタ対応にしてます。